### PR TITLE
maxheap.py

### DIFF
--- a/Data Structures/Heap/Python/maxheap.py
+++ b/Data Structures/Heap/Python/maxheap.py
@@ -1,0 +1,24 @@
+import heapq
+
+class Solution:
+
+    def kClosest(self, points: List[List[int]], K: int) -> List[List[int]]:
+        
+        maxHeap = []
+        
+        for (x, y) in points:
+            distance = math.sqrt(x*x + y*y)
+            
+            if len(maxHeap) >= K:
+                if -1 * distance > maxHeap[0][0]:
+                    heapq.heappushpop(maxHeap, [-1 * distance, [x, y]])
+            else:
+                heapq.heappush(maxHeap, [-1 * distance, [x, y]])
+        
+        resList = []
+        
+        for _ in range(K):
+            resList.append(heapq.heappop(maxHeap)[1])
+        
+        # return the list
+        return resList


### PR DESCRIPTION
Since Python's heapq implementation does not have built in support for max heap, we can just invert the values stored into the heap so it functions as a max heap. Max heap is better than min heap because we don't actually have to store all N points into the heap, we just need to keep K min points.

Time Complexity: O(N Log(K))
Space Complexity: O(K)